### PR TITLE
Support for HDF 5 1.14

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -19,7 +19,7 @@ include(RequireQt)
 
 # Get Qt5
 require_qt(COMPONENTS Core)
-find_package(hdf5 CONFIG REQUIRED)
+include(UseHDF5)
 
 set(CMAKE_CXX_STANDARD 14)
 
@@ -96,13 +96,9 @@ else()
     target_compile_definitions(GenH5 PUBLIC GENH5_STATIC)
 endif()
 
-if (TARGET hdf5::hdf5 AND NOT TARGET hdf5-shared)
-    add_library(hdf5-shared ALIAS hdf5::hdf5)
-endif()
-
 set_target_properties(GenH5 PROPERTIES OUTPUT_NAME "genhfive${PROJECT_VERSION_MAJOR}")
 
-target_link_libraries(GenH5 PUBLIC Qt${QT_VERSION_MAJOR}::Core PRIVATE hdf5-shared)
+target_link_libraries(GenH5 PUBLIC Qt${QT_VERSION_MAJOR}::Core PRIVATE hdf5::hdf5)
 
 target_include_directories(GenH5 PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -19,7 +19,7 @@ include(RequireQt)
 
 # Get Qt5
 require_qt(COMPONENTS Core)
-find_package(hdf5 1.12.0 CONFIG REQUIRED)
+find_package(hdf5 CONFIG REQUIRED)
 
 set(CMAKE_CXX_STANDARD 14)
 

--- a/src/cmake/UseHDF5.cmake
+++ b/src/cmake/UseHDF5.cmake
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: 2026 German Aerospace Center (DLR)
+# SPDX-License-Identifier: MPL-2.0+
+
+option(GENH5_HDF5_STATIC "Link HDF5 statically" OFF)
+
+find_package(hdf5 CONFIG REQUIRED)
+
+# hdf5::hdf5 might already be created by conan or other package managers
+if (NOT TARGET hdf5::hdf5)
+
+    # lets create an hdf5::hdf5 alias target based on the static/dynamic option
+    if (GENH5_HDF5_STATIC)
+        if (TARGET hdf5-static)
+            if (HDF5_ENABLE_Z_LIB_SUPPORT)
+                # One-time status message
+                if (NOT DEFINED GENH5_SEARCH_ZLIB_REPORTED)
+                    message("Found HDF5 with zlib support, searching for ZLIB...")
+                    set(GENH5_SEARCH_ZLIB_REPORTED TRUE CACHE INTERNAL
+                        "Whether zlib search has been reported")
+                endif()
+
+                find_package(ZLIB REQUIRED)
+            endif()
+
+            add_library(hdf5::hdf5 ALIAS hdf5-static)
+        else()
+            message(FATAL_ERROR "GENH5_HDF5_STATIC is ON but hdf5-static target not found")
+        endif()
+    else()
+        if (TARGET hdf5-shared)
+            add_library(hdf5::hdf5  ALIAS hdf5-shared)
+        else()
+            message(FATAL_ERROR "GENH5_HDF5_STATIC is OFF but hdf5-shared target not found")
+        endif()
+    endif()
+endif()

--- a/src/genh5_private.h
+++ b/src/genh5_private.h
@@ -13,6 +13,7 @@
 #include "genh5_group.h"
 
 #include <H5Ipublic.h>
+#include <H5Lpublic.h>
 #include <H5Apublic.h>
 
 #include <utility>

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -3,20 +3,15 @@
 
 project(GenH5-tests)
 
+list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
+
 if (NOT TARGET GenH5)
     find_package(GenH5 CONFIG REQUIRED)
 endif()
 
 if (NOT TARGET hdf5::hdf5)
-    find_package(hdf5 CONFIG REQUIRED)
+    include(UseHDF5)
 endif()
-
-# make conan and normal config files work
-if (TARGET hdf5::hdf5 AND NOT TARGET hdf5-shared)
-  add_library(hdf5-shared ALIAS hdf5::hdf5)
-endif()
-
-list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 
 if (NOT TARGET gtest)
     include(AddGoogleTest)
@@ -50,7 +45,7 @@ add_executable(H5UnitTest
 
 target_include_directories(H5UnitTest PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 
-get_target_property(HDF5_INCLUDE_DIRS hdf5-shared INTERFACE_INCLUDE_DIRECTORIES)
+get_target_property(HDF5_INCLUDE_DIRS hdf5::hdf5 INTERFACE_INCLUDE_DIRECTORIES)
 
 target_include_directories(H5UnitTest PRIVATE ${HDF5_INCLUDE_DIRS})
 

--- a/tests/unittests/cmake/UseHDF5.cmake
+++ b/tests/unittests/cmake/UseHDF5.cmake
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: 2026 German Aerospace Center (DLR)
+# SPDX-License-Identifier: MPL-2.0+
+
+option(GENH5_HDF5_STATIC "Link HDF5 statically" OFF)
+
+find_package(hdf5 CONFIG REQUIRED)
+
+# hdf5::hdf5 might already be created by conan or other package managers
+if (NOT TARGET hdf5::hdf5)
+
+    # lets create an hdf5::hdf5 alias target based on the static/dynamic option
+    if (GENH5_HDF5_STATIC)
+        if (TARGET hdf5-static)
+            if (HDF5_ENABLE_Z_LIB_SUPPORT)
+                # One-time status message
+                if (NOT DEFINED GENH5_SEARCH_ZLIB_REPORTED)
+                    message("Found HDF5 with zlib support, searching for ZLIB...")
+                    set(GENH5_SEARCH_ZLIB_REPORTED TRUE CACHE INTERNAL
+                        "Whether zlib search has been reported")
+                endif()
+
+                find_package(ZLIB REQUIRED)
+            endif()
+
+            add_library(hdf5::hdf5 ALIAS hdf5-static)
+        else()
+            message(FATAL_ERROR "GENH5_HDF5_STATIC is ON but hdf5-static target not found")
+        endif()
+    else()
+        if (TARGET hdf5-shared)
+            add_library(hdf5::hdf5  ALIAS hdf5-shared)
+        else()
+            message(FATAL_ERROR "GENH5_HDF5_STATIC is OFF but hdf5-shared target not found")
+        endif()
+    endif()
+endif()

--- a/tests/unittests/h5/test_01_version.cpp
+++ b/tests/unittests/h5/test_01_version.cpp
@@ -36,12 +36,6 @@ TEST_F(TestH5, verionMacros)
     EXPECT_STREQ(GENH5_VERSION_ADDITIONAL, GenH5::Version::subrelease());
 }
 
-TEST_F(TestH5, hdf5Version)
-{
-    EXPECT_TRUE(0x010c00 <= GenH5::Version::hdf5());
-    EXPECT_TRUE(0x010d00 > GenH5::Version::hdf5());
-}
-
 TEST_F(TestH5, verionCheck)
 {
     EXPECT_TRUE(GENH5_VCHECK(1, 1, 1) > 0x010100);

--- a/tests/unittests/h5/test_h5_abstractdataset.cpp
+++ b/tests/unittests/h5/test_h5_abstractdataset.cpp
@@ -216,7 +216,7 @@ TEST_F(TestH5AbstractDataSet, writeTooManyElements)
 {
     // when data.length != dataspace.sum
     // to many elements
-    GenH5::Vector<int> dataLong = intData.mid(0, 3) + intData;
+    GenH5::Vector<int> dataLong = intData.mid(0, 3) + intData.values();
 
     // writing more than needed is technically allowed
     EXPECT_TRUE(dataset.write(dataLong));


### PR DESCRIPTION
This PR adds support for HDF5 1.14.

It actually does a bit more namely,
 - Support HDF5 != 1.12 by removing the strict 1.12 requirement and fixing up one include
 - Improved build support for linking against static hdf5 libraries
 - Fixed up one test compilation with qt6, where the implicit conversion of the Genh5::Data did not correctly work, hence i used `.value` to fix it up

The file `UseUDF5` should absract away the differences between conan targets, static and shared libraries, making sure, that the alias target hdf5::hdf5 always exists.