### PR TITLE
Support HDF5 1.14 typedef changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Predefined static instances of `DataSpace` and `DataType` were changed to be static member functions instead of static members. For example: `DataSpace::Null` is now `DataSpace::Null()`. - #126
 - Wrapped native HDF5 symbols (structs, enums, typedefs etc.) in header file `genh5_static.h`. These are binary compatible to the corresponding HDF5 symbols. Some enum values and structs are not made available in GenH5 yet, since only the required enum values and symbols were wrapped. - #51
 - GenH5 can now statically link HDF5. - #51
+- The typedefs `hsize_t`, `hssize_t`, `hid_t`, and `herr_t` were moved from the global namespace to `GenH5` to support newer HDF5 versions. Code that explicitly uses these GenH5 types must qualify them, for example by replacing `hsize_t` with `GenH5::hsize_t`. Code that only passes values to the GenH5 API does not need to change. - #145
 
 ### Added
 - Added methods for accessing sign and CSET of datatypes. - #51

--- a/src/genh5_attribute.cpp
+++ b/src/genh5_attribute.cpp
@@ -34,7 +34,7 @@ GenH5::Attribute::Attribute(hid_t id) :
     m_id.inc();
 }
 
-hid_t
+GenH5::hid_t
 GenH5::Attribute::id() const noexcept
 {
     return m_id;

--- a/src/genh5_dataset.cpp
+++ b/src/genh5_dataset.cpp
@@ -300,8 +300,8 @@ GenH5::DataSet::resize(Dimensions const& dimensions) noexcept(false)
     herr_t err = 0;
     if (dimensions != dspace.dimensions())
     {
-        auto hdf5Dimensions = details::toHdf5Dimensions(dimensions);
-        err = H5Dset_extent(m_id, hdf5Dimensions.constData());
+        auto const& h5Dimensions = compat::toH5Dimensions(dimensions);
+        err = H5Dset_extent(m_id, h5Dimensions.constData());
     }
     return err >= 0;
 }

--- a/src/genh5_dataset.cpp
+++ b/src/genh5_dataset.cpp
@@ -90,7 +90,7 @@ GenH5::DataSet::swap(DataSet& other) noexcept
     swap(m_id, other.m_id);
 }
 
-hid_t
+GenH5::hid_t
 GenH5::DataSet::id() const noexcept
 {
     return m_id;
@@ -300,7 +300,8 @@ GenH5::DataSet::resize(Dimensions const& dimensions) noexcept(false)
     herr_t err = 0;
     if (dimensions != dspace.dimensions())
     {
-        err = H5Dset_extent(m_id, dimensions.constData());
+        auto hdf5Dimensions = details::toHdf5Dimensions(dimensions);
+        err = H5Dset_extent(m_id, hdf5Dimensions.constData());
     }
     return err >= 0;
 }

--- a/src/genh5_datasetcproperties.cpp
+++ b/src/genh5_datasetcproperties.cpp
@@ -56,8 +56,8 @@ GenH5::DataSetCProperties::autoChunk(DataSpace const& dataspace) noexcept
 
     std::replace_if(std::begin(dimensions), std::end(dimensions),
                     std::bind(std::less<>(),
-                              std::placeholders::_1, 1),
-                    1);
+                              std::placeholders::_1, 1ull),
+                    1ull);
 
     // TODO: implement logic to generate optimal chunking layout
 
@@ -81,9 +81,8 @@ GenH5::DataSetCProperties::setChunkDimensions(Dimensions const& dimensions
         };
     }
 
-    auto hdf5Dimensions = details::toHdf5Dimensions(dimensions);
-    if (H5Pset_chunk(m_id, hdf5Dimensions.length(),
-                     hdf5Dimensions.constData()))
+    auto const& h5Dimensions = compat::toH5Dimensions(dimensions);
+    if (H5Pset_chunk(m_id, h5Dimensions.length(), h5Dimensions.constData()))
     {
         throw PropertyListException{
             GENH5_MAKE_EXECEPTION_STR() "Chunking failed"
@@ -174,10 +173,10 @@ GenH5::DataSetCProperties::chunkDimensions() const noexcept
     {
         return {};
     }
-
-    details::Hdf5Dimensions dimensions(H5Pget_chunk(m_id, 0, nullptr));
+    
+    compat::H5Dimensions dimensions(H5Pget_chunk(m_id, 0, nullptr));
     H5Pget_chunk(m_id, dimensions.size(), dimensions.data());
-    return details::fromHdf5Dimensions(dimensions);
+    return compat::fromH5Dimensions(dimensions);
 }
 
 void

--- a/src/genh5_datasetcproperties.cpp
+++ b/src/genh5_datasetcproperties.cpp
@@ -64,7 +64,7 @@ GenH5::DataSetCProperties::autoChunk(DataSpace const& dataspace) noexcept
     return dimensions;
 }
 
-hid_t
+GenH5::hid_t
 GenH5::DataSetCProperties::id() const noexcept
 {
     return m_id;
@@ -81,7 +81,9 @@ GenH5::DataSetCProperties::setChunkDimensions(Dimensions const& dimensions
         };
     }
 
-    if (H5Pset_chunk(m_id, dimensions.length(), dimensions.data()))
+    auto hdf5Dimensions = details::toHdf5Dimensions(dimensions);
+    if (H5Pset_chunk(m_id, hdf5Dimensions.length(),
+                     hdf5Dimensions.constData()))
     {
         throw PropertyListException{
             GENH5_MAKE_EXECEPTION_STR() "Chunking failed"
@@ -173,9 +175,9 @@ GenH5::DataSetCProperties::chunkDimensions() const noexcept
         return {};
     }
 
-    Dimensions dims(H5Pget_chunk(m_id, 0, nullptr));
-    H5Pget_chunk(m_id, dims.size(), dims.data());
-    return dims;
+    details::Hdf5Dimensions dimensions(H5Pget_chunk(m_id, 0, nullptr));
+    H5Pget_chunk(m_id, dimensions.size(), dimensions.data());
+    return details::fromHdf5Dimensions(dimensions);
 }
 
 void

--- a/src/genh5_dataspace.cpp
+++ b/src/genh5_dataspace.cpp
@@ -55,7 +55,11 @@ GenH5::DataSpace::DataSpace(hid_t id) :
 }
 
 GenH5::DataSpace::DataSpace(Dimensions const& dimensions) noexcept(false) :
-    m_id(H5Screate_simple(dimensions.size(), dimensions.constData(), nullptr))
+    m_id([&dimensions] {
+        auto hdf5Dimensions = details::toHdf5Dimensions(dimensions);
+        return H5Screate_simple(hdf5Dimensions.size(),
+                                hdf5Dimensions.constData(), nullptr);
+    }())
 {
     if (m_id < 0)
     {
@@ -70,7 +74,7 @@ GenH5::DataSpace::DataSpace(std::initializer_list<hsize_t> initlist
     DataSpace{Dimensions{initlist}}
 { }
 
-hid_t
+GenH5::hid_t
 GenH5::DataSpace::id() const noexcept
 {
     return m_id;
@@ -103,13 +107,12 @@ GenH5::DataSpace::dimensions() const noexcept
         return {};
     }
 
-    Dimensions dims;
-    dims.resize(size);
-    H5Sget_simple_extent_dims(m_id, dims.data(), nullptr);
-    return dims;
+    details::Hdf5Dimensions dimensions(size);
+    H5Sget_simple_extent_dims(m_id, dimensions.data(), nullptr);
+    return details::fromHdf5Dimensions(dimensions);
 }
 
-hssize_t
+GenH5::hssize_t
 GenH5::DataSpace::selectionSize() const noexcept
 {
     return H5Sget_select_npoints(m_id);
@@ -184,9 +187,15 @@ GenH5::DataSpaceSelection::commit() noexcept(false)
     testSelection(m_stride, dims, 1);
     testSelection(m_block, dims, 1);
 
-    herr_t err = H5Sselect_hyperslab(m_space.id(), static_cast<H5S_seloper_t>(m_op),
-                                     m_offset.constData(), m_stride.constData(),
-                                     m_count.constData(), m_block.constData());
+    auto offset = details::toHdf5Dimensions(m_offset);
+    auto stride = details::toHdf5Dimensions(m_stride);
+    auto count = details::toHdf5Dimensions(m_count);
+    auto block = details::toHdf5Dimensions(m_block);
+
+    herr_t err = H5Sselect_hyperslab(
+        m_space.id(), static_cast<H5S_seloper_t>(m_op),
+        offset.constData(), stride.constData(), count.constData(),
+        block.constData());
 
     if (err < 0)
     {

--- a/src/genh5_dataspace.cpp
+++ b/src/genh5_dataspace.cpp
@@ -56,9 +56,10 @@ GenH5::DataSpace::DataSpace(hid_t id) :
 
 GenH5::DataSpace::DataSpace(Dimensions const& dimensions) noexcept(false) :
     m_id([&dimensions] {
-        auto hdf5Dimensions = details::toHdf5Dimensions(dimensions);
-        return H5Screate_simple(hdf5Dimensions.size(),
-                                hdf5Dimensions.constData(), nullptr);
+        auto const& h5Dimensions = compat::toH5Dimensions(dimensions);
+        return H5Screate_simple(h5Dimensions.size(),
+                                h5Dimensions.constData(),
+                                nullptr);
     }())
 {
     if (m_id < 0)
@@ -106,10 +107,10 @@ GenH5::DataSpace::dimensions() const noexcept
     {
         return {};
     }
-
-    details::Hdf5Dimensions dimensions(size);
+    
+    compat::H5Dimensions dimensions(size);
     H5Sget_simple_extent_dims(m_id, dimensions.data(), nullptr);
-    return details::fromHdf5Dimensions(dimensions);
+    return compat::fromH5Dimensions(dimensions);
 }
 
 GenH5::hssize_t
@@ -187,10 +188,10 @@ GenH5::DataSpaceSelection::commit() noexcept(false)
     testSelection(m_stride, dims, 1);
     testSelection(m_block, dims, 1);
 
-    auto offset = details::toHdf5Dimensions(m_offset);
-    auto stride = details::toHdf5Dimensions(m_stride);
-    auto count = details::toHdf5Dimensions(m_count);
-    auto block = details::toHdf5Dimensions(m_block);
+    auto const& offset = compat::toH5Dimensions(m_offset);
+    auto const& stride = compat::toH5Dimensions(m_stride);
+    auto const& count  = compat::toH5Dimensions(m_count);
+    auto const& block  = compat::toH5Dimensions(m_block);
 
     herr_t err = H5Sselect_hyperslab(
         m_space.id(), static_cast<H5S_seloper_t>(m_op),

--- a/src/genh5_datatype.cpp
+++ b/src/genh5_datatype.cpp
@@ -199,11 +199,11 @@ GenH5::DataType::array(DataType const& type,
     static const std::string errMsg =
             GENH5_MAKE_EXECEPTION_STR() "Failed to create array type";
 
-    auto hdf5Dimensions = details::toHdf5Dimensions(dims);
     return makeType(
-                [id = type.m_id, len = hdf5Dimensions.length(),
-                 ptr = hdf5Dimensions.constData()](){
-        return H5Tarray_create(id, len, ptr);
+                [id = type.m_id,
+                 dimensions = details::toHdf5Dimensions(dims)](){
+        return H5Tarray_create(id, dimensions.length(),
+                               dimensions.constData());
     }, errMsg);
 }
 

--- a/src/genh5_datatype.cpp
+++ b/src/genh5_datatype.cpp
@@ -199,11 +199,9 @@ GenH5::DataType::array(DataType const& type,
     static const std::string errMsg =
             GENH5_MAKE_EXECEPTION_STR() "Failed to create array type";
 
-    return makeType(
-                [id = type.m_id,
-                 dimensions = details::toHdf5Dimensions(dims)](){
-        return H5Tarray_create(id, dimensions.length(),
-                               dimensions.constData());
+    return makeType([id = type.m_id, &dims](){
+        auto const& dimensions = compat::toH5Dimensions(dims);
+        return H5Tarray_create(id, dimensions.length(), dimensions.constData());
     }, errMsg);
 }
 
@@ -382,11 +380,11 @@ GenH5::DataType::arrayDimensions() const noexcept
     {
         return {};
     }
-
-    details::Hdf5Dimensions dimensions;
+    
+    compat::H5Dimensions dimensions;
     dimensions.resize(H5Tget_array_ndims(m_id));
     H5Tget_array_dims(m_id, dimensions.data());
-    return details::fromHdf5Dimensions(dimensions);
+    return compat::fromH5Dimensions(dimensions);
 }
 
 GenH5::CompoundMembers

--- a/src/genh5_datatype.cpp
+++ b/src/genh5_datatype.cpp
@@ -199,8 +199,10 @@ GenH5::DataType::array(DataType const& type,
     static const std::string errMsg =
             GENH5_MAKE_EXECEPTION_STR() "Failed to create array type";
 
+    auto hdf5Dimensions = details::toHdf5Dimensions(dims);
     return makeType(
-                [id = type.m_id, len = dims.length(), ptr = dims.constData()](){
+                [id = type.m_id, len = hdf5Dimensions.length(),
+                 ptr = hdf5Dimensions.constData()](){
         return H5Tarray_create(id, len, ptr);
     }, errMsg);
 }
@@ -301,7 +303,7 @@ GenH5::DataType::DataType(hid_t id) :
     m_id.inc();
 }
 
-hid_t
+GenH5::hid_t
 GenH5::DataType::id() const noexcept
 {
     return m_id;
@@ -381,10 +383,10 @@ GenH5::DataType::arrayDimensions() const noexcept
         return {};
     }
 
-    Dimensions dims;
-    dims.resize(H5Tget_array_ndims(m_id));
-    H5Tget_array_dims(m_id, dims.data());
-    return dims;
+    details::Hdf5Dimensions dimensions;
+    dimensions.resize(H5Tget_array_ndims(m_id));
+    H5Tget_array_dims(m_id, dimensions.data());
+    return details::fromHdf5Dimensions(dimensions);
 }
 
 GenH5::CompoundMembers

--- a/src/genh5_file.cpp
+++ b/src/genh5_file.cpp
@@ -122,7 +122,7 @@ GenH5::File::File(String path, FileAccessFlags flags)
     }
 }
 
-hid_t
+GenH5::hid_t
 GenH5::File::id() const noexcept
 {
     return m_id;

--- a/src/genh5_group.cpp
+++ b/src/genh5_group.cpp
@@ -43,7 +43,7 @@ GenH5::Group::Group(hid_t id) :
     m_id.inc();
 }
 
-hid_t
+GenH5::hid_t
 GenH5::Group::id() const noexcept
 {
     return m_id;
@@ -256,7 +256,7 @@ GenH5::Group::findChildNodes(IterationType iterType,
 
     if (iterType == FindDirectOnly)
     {
-        hsize_t idx = 0;
+        ::hsize_t idx = 0;
         H5Literate(m_id, h5index, h5order, &idx, alg::accumulateNodes, &data);
     }
     else
@@ -267,7 +267,7 @@ GenH5::Group::findChildNodes(IterationType iterType,
     return nodes;
 }
 
-herr_t
+GenH5::herr_t
 GenH5::Group::iterateChildNodes(NodeIterationFunction iterFunction,
                                 IterationType iterType,
                                 IterationFilter iterFilter,
@@ -284,7 +284,7 @@ GenH5::Group::iterateChildNodes(NodeIterationFunction iterFunction,
 
     if (iterType == FindDirectOnly)
     {
-        hsize_t idx = 0;
+        ::hsize_t idx = 0;
         error = H5Literate(m_id, h5index, h5order, &idx,
                            alg::foreachNode, &data);
     }

--- a/src/genh5_hooks.cpp
+++ b/src/genh5_hooks.cpp
@@ -19,7 +19,7 @@ namespace HookDataBase
 /// Each item in the array corresponds to the HookType of value "index+1".
 using Entry = std::array<GenH5::Hook, GenH5::NumberOfHooks>;
 
-using DataBase = std::unordered_map<hid_t, Entry>;
+using DataBase = std::unordered_map<GenH5::hid_t, Entry>;
 
 static DataBase& instance()
 {

--- a/src/genh5_node.cpp
+++ b/src/genh5_node.cpp
@@ -263,7 +263,7 @@ GenH5::Node::findAttributes(String const& path,
 {
     GenH5::Vector<GenH5::AttributeInfo> attributes;
 
-    hsize_t idx_ = 0;
+    ::hsize_t idx_ = 0;
     H5Aiterate_by_name(id(), path.constData(),
                        static_cast<H5_index_t>(iterIndex),
                        static_cast<H5_iter_order_t>(iterOrder), &idx_,
@@ -272,7 +272,7 @@ GenH5::Node::findAttributes(String const& path,
     return attributes;
 }
 
-herr_t
+GenH5::herr_t
 GenH5::Node::iterateAttributes(AttributeIterationFunction iterFunction,
                                IterationIndex iterIndex,
                                IterationOrder iterOrder) const noexcept
@@ -281,7 +281,7 @@ GenH5::Node::iterateAttributes(AttributeIterationFunction iterFunction,
                              iterIndex, iterOrder);
 }
 
-herr_t
+GenH5::herr_t
 GenH5::Node::iterateAttributes(String const& path,
                                AttributeIterationFunction iterFunction,
                                IterationIndex iterIndex,
@@ -292,7 +292,7 @@ GenH5::Node::iterateAttributes(String const& path,
 
     alg::IterForeachAttrData data{this, &iterFunction};
 
-    hsize_t idx_ = 0;
+    ::hsize_t idx_ = 0;
     herr_t error = H5Aiterate_by_name(id(), path.constData(),
                                       static_cast<H5_index_t>(iterIndex),
                                       static_cast<H5_iter_order_t>(iterOrder),

--- a/src/genh5_private.h
+++ b/src/genh5_private.h
@@ -56,15 +56,19 @@ struct resolve_dimensions<hsize_t>
 
 using H5Dimensions = typename resolve_dimensions<::hsize_t>::type;
 
-template<typename Dim, typename RetVal = Dimensions>
-auto toH5Dimensions(Dim const& dimensions)
+template<typename Dim,
+         typename RetVal = Dimensions,
+         typename = std::enable_if_t<std::is_lvalue_reference<Dim>::value>>
+auto toH5Dimensions(Dim&& dimensions)
     -> std::enable_if_t<std::is_same<H5Dimensions, Dimensions>::value, RetVal const&>
 {
     return dimensions;
 }
 
-template<typename Dim, typename RetVal = H5Dimensions>
-auto toH5Dimensions(Dim const& dimensions)
+template<typename Dim,
+         typename RetVal = H5Dimensions,
+         typename = std::enable_if_t<std::is_lvalue_reference<Dim>::value>>
+auto toH5Dimensions(Dim&& dimensions)
     -> std::enable_if_t<!std::is_same<H5Dimensions, Dimensions>::value, RetVal>
 {
     H5Dimensions result(dimensions.size());
@@ -77,14 +81,14 @@ auto toH5Dimensions(Dim const& dimensions)
 
 
 template<typename Dim, typename RetVal = Dimensions>
-auto fromH5Dimensions(Dim const& dimensions)
-     -> std::enable_if_t<std::is_same<H5Dimensions, Dimensions>::value, RetVal const&>
+auto fromH5Dimensions(Dim&& dimensions)
+     -> std::enable_if_t<std::is_same<H5Dimensions, Dimensions>::value, RetVal>
 {
     return dimensions;
 }
 
 template<typename Dim, typename RetVal = Dimensions>
-auto fromH5Dimensions(Dim const& dimensions)
+auto fromH5Dimensions(Dim&& dimensions)
     -> std::enable_if_t<!std::is_same<H5Dimensions, Dimensions>::value, RetVal>
 {
     Dimensions result(dimensions.size());

--- a/src/genh5_private.h
+++ b/src/genh5_private.h
@@ -16,6 +16,7 @@
 #include <H5Lpublic.h>
 #include <H5Apublic.h>
 
+#include <algorithm>
 #include <type_traits>
 #include <utility>
 
@@ -43,13 +44,11 @@ using Hdf5Dimensions = Vector<::hsize_t>;
 inline Hdf5Dimensions
 toHdf5Dimensions(Dimensions const& dimensions)
 {
-    Hdf5Dimensions result;
-    result.reserve(dimensions.size());
-
-    for (hsize_t dimension : dimensions)
-    {
-        result.push_back(static_cast<::hsize_t>(dimension));
-    }
+    Hdf5Dimensions result(dimensions.size());
+    std::transform(dimensions.cbegin(), dimensions.cend(), result.begin(),
+                   [](hsize_t dimension) {
+        return static_cast<::hsize_t>(dimension);
+    });
 
     return result;
 }
@@ -57,13 +56,11 @@ toHdf5Dimensions(Dimensions const& dimensions)
 inline Dimensions
 fromHdf5Dimensions(Hdf5Dimensions const& dimensions)
 {
-    Dimensions result;
-    result.reserve(dimensions.size());
-
-    for (::hsize_t dimension : dimensions)
-    {
-        result.push_back(static_cast<hsize_t>(dimension));
-    }
+    Dimensions result(dimensions.size());
+    std::transform(dimensions.cbegin(), dimensions.cend(), result.begin(),
+                   [](::hsize_t dimension) {
+        return static_cast<hsize_t>(dimension);
+    });
 
     return result;
 }

--- a/src/genh5_private.h
+++ b/src/genh5_private.h
@@ -26,6 +26,36 @@ namespace GenH5
 namespace details
 {
 
+using Hdf5Dimensions = Vector<::hsize_t>;
+
+inline Hdf5Dimensions
+toHdf5Dimensions(Dimensions const& dimensions)
+{
+    Hdf5Dimensions result;
+    result.reserve(dimensions.size());
+
+    for (hsize_t dimension : dimensions)
+    {
+        result.push_back(static_cast<::hsize_t>(dimension));
+    }
+
+    return result;
+}
+
+inline Dimensions
+fromHdf5Dimensions(Hdf5Dimensions const& dimensions)
+{
+    Dimensions result;
+    result.reserve(dimensions.size());
+
+    for (::hsize_t dimension : dimensions)
+    {
+        result.push_back(static_cast<hsize_t>(dimension));
+    }
+
+    return result;
+}
+
 /// Helper function for creating T
 template <typename T,
           typename Ex,

--- a/src/genh5_private.h
+++ b/src/genh5_private.h
@@ -11,7 +11,6 @@
 #define GENH5_PRIVATE_H
 
 #include "genh5_group.h"
-#include "genh5_typetraits.h"
 
 #include <H5Ipublic.h>
 #include <H5Lpublic.h>
@@ -56,47 +55,46 @@ struct resolve_dimensions<hsize_t>
 
 using H5Dimensions = typename resolve_dimensions<::hsize_t>::type;
 
-template<typename Dim,
-         typename RetVal = Dimensions,
-         typename = std::enable_if_t<std::is_lvalue_reference<Dim>::value>>
+inline constexpr bool h5DimensionsMatch = std::is_same_v<H5Dimensions, Dimensions>;
+
+template<typename Dim>
 auto toH5Dimensions(Dim&& dimensions)
-    -> std::enable_if_t<std::is_same<H5Dimensions, Dimensions>::value, RetVal const&>
 {
-    return dimensions;
+    if constexpr (h5DimensionsMatch)
+    {
+        return std::forward<Dim>(dimensions);
+    }
+    else
+    {
+        H5Dimensions result(dimensions.size());
+        std::transform(dimensions.cbegin(),
+                       dimensions.cend(),
+                       result.begin(),
+                       [](hsize_t dimension) {
+            return static_cast<::hsize_t>(dimension);
+         });
+        return result;
+    }
 }
 
-template<typename Dim,
-         typename RetVal = H5Dimensions,
-         typename = std::enable_if_t<std::is_lvalue_reference<Dim>::value>>
-auto toH5Dimensions(Dim&& dimensions)
-    -> std::enable_if_t<!std::is_same<H5Dimensions, Dimensions>::value, RetVal>
-{
-    H5Dimensions result(dimensions.size());
-    std::transform(dimensions.cbegin(), dimensions.cend(), result.begin(),
-                   [](hsize_t dimension) {
-        return static_cast<::hsize_t>(dimension);
-    });
-    return result;
-}
-
-
-template<typename Dim, typename RetVal = Dimensions>
+template<typename Dim>
 auto fromH5Dimensions(Dim&& dimensions)
-     -> std::enable_if_t<std::is_same<H5Dimensions, Dimensions>::value, RetVal>
 {
-    return dimensions;
-}
-
-template<typename Dim, typename RetVal = Dimensions>
-auto fromH5Dimensions(Dim&& dimensions)
-    -> std::enable_if_t<!std::is_same<H5Dimensions, Dimensions>::value, RetVal>
-{
-    Dimensions result(dimensions.size());
-    std::transform(dimensions.cbegin(), dimensions.cend(), result.begin(),
-                   [](hsize_t dimension) {
-        return static_cast<hsize_t>(dimension);
-    });
-    return result;
+    if constexpr (h5DimensionsMatch)
+    {
+        return std::forward<Dim>(dimensions);
+    }
+    else
+    {
+        Dimensions result(dimensions.size());
+        std::transform(dimensions.cbegin(),
+                       dimensions.cend(),
+                       result.begin(),
+                       [](hsize_t dimension) {
+            return static_cast<hsize_t>(dimension);
+        });
+        return result;
+    }
 }
 
 } // namespace compat

--- a/src/genh5_private.h
+++ b/src/genh5_private.h
@@ -16,6 +16,7 @@
 #include <H5Lpublic.h>
 #include <H5Apublic.h>
 
+#include <type_traits>
 #include <utility>
 
 #include <QDebug>
@@ -25,6 +26,17 @@ namespace GenH5
 
 namespace details
 {
+
+static_assert(sizeof(hsize_t) == sizeof(::hsize_t),
+              "GenH5 and HDF5 dimension types must have the same size");
+static_assert(std::is_signed<hsize_t>::value ==
+                  std::is_signed<::hsize_t>::value,
+              "GenH5 and HDF5 dimension types must have the same signedness");
+static_assert(sizeof(hssize_t) == sizeof(::hssize_t),
+              "GenH5 and HDF5 signed dimension types must have the same size");
+static_assert(std::is_signed<hssize_t>::value ==
+                  std::is_signed<::hssize_t>::value,
+              "GenH5 and HDF5 signed dimension types must have the same signedness");
 
 using Hdf5Dimensions = Vector<::hsize_t>;
 

--- a/src/genh5_private.h
+++ b/src/genh5_private.h
@@ -11,6 +11,7 @@
 #define GENH5_PRIVATE_H
 
 #include "genh5_group.h"
+#include "genh5_typetraits.h"
 
 #include <H5Ipublic.h>
 #include <H5Lpublic.h>
@@ -20,50 +21,84 @@
 #include <type_traits>
 #include <utility>
 
+#include <QVarLengthArray>
 #include <QDebug>
 
 namespace GenH5
 {
 
-namespace details
+// HDF5 library compatibility
+namespace compat
 {
 
 static_assert(sizeof(hsize_t) == sizeof(::hsize_t),
-              "GenH5 and HDF5 dimension types must have the same size");
-static_assert(std::is_signed<hsize_t>::value ==
-                  std::is_signed<::hsize_t>::value,
-              "GenH5 and HDF5 dimension types must have the same signedness");
+              "GenH5 and HDF5 hsize_t type must have the same size");
+static_assert(std::is_signed<hsize_t>::value == std::is_signed<::hsize_t>::value,
+              "GenH5 and HDF5 hsize_t type must have the same signedness");
+
 static_assert(sizeof(hssize_t) == sizeof(::hssize_t),
-              "GenH5 and HDF5 signed dimension types must have the same size");
-static_assert(std::is_signed<hssize_t>::value ==
-                  std::is_signed<::hssize_t>::value,
-              "GenH5 and HDF5 signed dimension types must have the same signedness");
+              "GenH5 and HDF5 hssize_t type must have the same size");
+static_assert(std::is_signed<hssize_t>::value == std::is_signed<::hssize_t>::value,
+              "GenH5 and HDF5 hssize_t type must have the same signedness");
 
-using Hdf5Dimensions = Vector<::hsize_t>;
-
-inline Hdf5Dimensions
-toHdf5Dimensions(Dimensions const& dimensions)
+// helper structs to resolve whether we need a conversion or not
+template<typename T>
+struct resolve_dimensions
 {
-    Hdf5Dimensions result(dimensions.size());
+    using type = QVarLengthArray<::hsize_t, 16>;
+};
+
+template<>
+struct resolve_dimensions<hsize_t>
+{
+    using type = Dimensions;
+};
+
+using H5Dimensions = typename resolve_dimensions<::hsize_t>::type;
+
+template<typename Dim, typename RetVal = Dimensions>
+auto toH5Dimensions(Dim const& dimensions)
+    -> std::enable_if_t<std::is_same<H5Dimensions, Dimensions>::value, RetVal const&>
+{
+    return dimensions;
+}
+
+template<typename Dim, typename RetVal = H5Dimensions>
+auto toH5Dimensions(Dim const& dimensions)
+    -> std::enable_if_t<!std::is_same<H5Dimensions, Dimensions>::value, RetVal>
+{
+    H5Dimensions result(dimensions.size());
     std::transform(dimensions.cbegin(), dimensions.cend(), result.begin(),
                    [](hsize_t dimension) {
         return static_cast<::hsize_t>(dimension);
     });
-
     return result;
 }
 
-inline Dimensions
-fromHdf5Dimensions(Hdf5Dimensions const& dimensions)
+
+template<typename Dim, typename RetVal = Dimensions>
+auto fromH5Dimensions(Dim const& dimensions)
+     -> std::enable_if_t<std::is_same<H5Dimensions, Dimensions>::value, RetVal const&>
+{
+    return dimensions;
+}
+
+template<typename Dim, typename RetVal = Dimensions>
+auto fromH5Dimensions(Dim const& dimensions)
+    -> std::enable_if_t<!std::is_same<H5Dimensions, Dimensions>::value, RetVal>
 {
     Dimensions result(dimensions.size());
     std::transform(dimensions.cbegin(), dimensions.cend(), result.begin(),
-                   [](::hsize_t dimension) {
+                   [](hsize_t dimension) {
         return static_cast<hsize_t>(dimension);
     });
-
     return result;
 }
+
+} // namespace compat
+
+namespace details
+{
 
 /// Helper function for creating T
 template <typename T,

--- a/src/genh5_typedefs.h
+++ b/src/genh5_typedefs.h
@@ -22,9 +22,9 @@ namespace GenH5
 {
 
 /// wrapper for `hsize_t`
-using hsize_t  = unsigned long long;
+using hsize_t  = uint64_t;
 /// wrapper for `hssize_t`
-using hssize_t = signed long long;
+using hssize_t = int64_t;
 /// wrapper for `hid_t`
 using hid_t  = int64_t;
 /// wrapper for `herr_t`

--- a/src/genh5_typedefs.h
+++ b/src/genh5_typedefs.h
@@ -18,17 +18,17 @@
 
 #include <stdint.h>
 
-/// include `hsize_t`
-using hsize_t  = unsigned long long;
-/// include `hssize_t`
-using hssize_t =  signed long long;
-/// include `hid_t`
-using hid_t  = int64_t;
-/// include `herr_t`
-using herr_t = int;
-
 namespace GenH5
 {
+
+/// wrapper for `hsize_t`
+using hsize_t  = unsigned long long;
+/// wrapper for `hssize_t`
+using hssize_t = signed long long;
+/// wrapper for `hid_t`
+using hid_t  = int64_t;
+/// wrapper for `herr_t`
+using herr_t = int;
 
 namespace details
 {

--- a/tests/unittests/h5/test_01_typedefs.cpp
+++ b/tests/unittests/h5/test_01_typedefs.cpp
@@ -10,6 +10,7 @@
 #include "gtest/gtest.h"
 
 #include <genh5_typedefs.h>
+#include <genh5_utils.h>
 
 #include <H5public.h>
 #include <H5Tpublic.h>
@@ -17,6 +18,21 @@
 #include <H5Opublic.h>
 #include <H5Spublic.h>
 
+TEST(Test_01, tuple_layout)
+{
+    GenH5::Comp<int, double> tuple;
+
+    size_t offset_int    =
+        reinterpret_cast<size_t>(&GenH5::get<0>(tuple)) -
+        reinterpret_cast<size_t>(&tuple);
+    size_t offset_double =
+        reinterpret_cast<size_t>(&GenH5::get<1>(tuple)) -
+        reinterpret_cast<size_t>(&tuple);
+
+    // NOTE: GenH5 (currently) only supports tuples where the layout is
+    // effectively reversed, meaning that here `double` comes before `int`!
+    ASSERT_GT(offset_int, offset_double);
+}
 
 TEST(Test_01, constant_reference_buffer_size)
 {

--- a/tests/unittests/h5/test_51_hooks.cpp
+++ b/tests/unittests/h5/test_51_hooks.cpp
@@ -99,7 +99,7 @@ TEST(Test_51_Hooks, execute_hook)
     GenH5::String dsetPath;
     void const* dataPtr = nullptr;
 
-    auto preWrite = [&](hid_t id, void* contextObject){
+    auto preWrite = [&](GenH5::hid_t id, void* contextObject){
         preHookExecuted = true;
 
         auto* context = static_cast<GenH5::DataSetWriteHookContext*>(contextObject);
@@ -111,7 +111,7 @@ TEST(Test_51_Hooks, execute_hook)
         return GenH5::HookContinue;
     };
 
-    auto postWrite = [&](hid_t id, void* contextObject){
+    auto postWrite = [&](GenH5::hid_t id, void* contextObject){
         postHookExecuted = true;
 
         auto* context = static_cast<GenH5::DataSetWriteHookContext*>(contextObject);
@@ -145,7 +145,7 @@ TEST(Test_51_Hooks, execute_hook)
     qDebug() << "reopening file...";
 
     // file id is different -> hooks wont be executed
-    hid_t oldId = file.id();
+    GenH5::hid_t oldId = file.id();
     file = GenH5::File{filePath, GenH5::ReadWrite};
 
     ASSERT_NE(oldId, file.id());
@@ -238,12 +238,12 @@ TEST(Test_51_Hooks, hook_return_value)
     GenH5::HookReturnValue preHookReturnValue = GenH5::HookExitSuccess;
     GenH5::HookReturnValue postHookReturnValue = GenH5::HookExitFailure;
 
-    auto preWrite = [&](hid_t id, void* contextObject){
+    auto preWrite = [&](GenH5::hid_t id, void* contextObject){
         preHookExecuted = true;
         return preHookReturnValue;
     };
 
-    auto postWrite = [&](hid_t id, void* contextObject){
+    auto postWrite = [&](GenH5::hid_t id, void* contextObject){
         postHookExecuted = true;
         return postHookReturnValue;
     };

--- a/tests/unittests/h5/test_51_hooks.cpp
+++ b/tests/unittests/h5/test_51_hooks.cpp
@@ -172,7 +172,7 @@ TEST(Test_51_Hooks, execute_hook_closed_file)
     data.resize(100);
     std::iota(data.begin(), data.end(), 0);
 
-    hid_t fileId{};
+    GenH5::hid_t fileId{};
 
     // hooks are only active as long as the main file handle is alive
     {
@@ -180,12 +180,12 @@ TEST(Test_51_Hooks, execute_hook_closed_file)
         fileId = file.id();
         qDebug() << "registering hooks for file" << file.id();
 
-        auto preWrite = [&](hid_t id, void* contextObject){
+        auto preWrite = [&](GenH5::hid_t id, void* contextObject){
             preHookExecuted = true;
             return GenH5::HookContinue;
         };
 
-        auto postWrite = [&](hid_t id, void* contextObject){
+        auto postWrite = [&](GenH5::hid_t id, void* contextObject){
             postHookExecuted = true;
             return GenH5::HookContinue;
         };
@@ -213,7 +213,7 @@ TEST(Test_51_Hooks, execute_hook_closed_file)
     EXPECT_TRUE(GenH5::isValidId(dset.fileId().raw()));
 
     // hooks are now deleted, since main handle is closed
-    EXPECT_NE(dset.fileId(), fileId);
+    EXPECT_NE(dset.fileId().raw(), fileId);
     EXPECT_FALSE(GenH5::isValidId(fileId));
     EXPECT_FALSE(GenH5::findHook(dset.file(), GenH5::PreDataSetWriteHook));
     EXPECT_FALSE(GenH5::findHook(dset.file(), GenH5::PostDataSetWriteHook));

--- a/tests/unittests/h5/test_h5_data.cpp
+++ b/tests/unittests/h5/test_h5_data.cpp
@@ -686,8 +686,8 @@ TEST_F(TestH5Data, resize_setDimensions)
 
 TEST_F(TestH5Data, resize_array)
 {
-    constexpr hsize_t spaceLength = 10;
-    constexpr hsize_t arrLength = 5;
+    constexpr GenH5::hsize_t spaceLength = 10;
+    constexpr GenH5::hsize_t arrLength = 5;
 
     // for simple types
     auto space = GenH5::DataSpace::linear(spaceLength);
@@ -719,8 +719,8 @@ TEST_F(TestH5Data, resize_array)
 
 TEST_F(TestH5Data, resize_arrayCompound)
 {
-    constexpr hsize_t spaceLength = 10;
-    constexpr hsize_t arrLength = 5;
+    constexpr GenH5::hsize_t spaceLength = 10;
+    constexpr GenH5::hsize_t arrLength = 5;
 
     // for compound types
     auto space = GenH5::DataSpace::linear(spaceLength);

--- a/tests/unittests/h5/test_h5_dataset.cpp
+++ b/tests/unittests/h5/test_h5_dataset.cpp
@@ -241,10 +241,10 @@ TEST_F(TestH5DataSet, h5selection) // test selection in hdf5
         // file space layout
         H5::DataSpace hspace{dspace.toH5()};
 
-        QVector<hsize_t> count{2, 5};
-        QVector<hsize_t> offset{0, 1};
-        QVector<hsize_t> stride{1, 1};
-        QVector<hsize_t> block{1, 1};
+        QVector<GenH5::hsize_t> count{2, 5};
+        QVector<GenH5::hsize_t> offset{0, 1};
+        QVector<GenH5::hsize_t> stride{1, 1};
+        QVector<GenH5::hsize_t> block{1, 1};
 
         // file space selection
         hspace.selectHyperslab(H5S_SELECT_SET,
@@ -254,7 +254,7 @@ TEST_F(TestH5DataSet, h5selection) // test selection in hdf5
                                block.constData());
 
         // memory layout
-        QVector<hsize_t> memDims{10};
+        QVector<GenH5::hsize_t> memDims{10};
         H5::DataSpace memspace{memDims.length(), memDims.constData()};
 
         dset.toH5().write(plaindata,
@@ -329,4 +329,3 @@ TEST_F(TestH5DataSet, h5selection) // test selection in hdf5
     }
 }
 #endif
-

--- a/tests/unittests/h5/test_h5_file.cpp
+++ b/tests/unittests/h5/test_h5_file.cpp
@@ -140,7 +140,7 @@ TEST_F(TestH5File, fileSuffix)
 // Issue 147: Accessing the file id of objects may cause the underlying file handles to leak
 TEST_F(TestH5File, issue_147)
 {
-    hid_t fileId{};
+    GenH5::hid_t fileId{};
 
     // create file
     {

--- a/tests/unittests/h5/test_h5_iteration.cpp
+++ b/tests/unittests/h5/test_h5_iteration.cpp
@@ -225,7 +225,7 @@ TEST_F(TestH5Iteration, sample)
     EXPECT_EQ(bAttrs.size(), 2);
 
     b.iterateChildNodes([](GenH5::Group const& parent,
-                           GenH5::NodeInfo const& info) -> herr_t {
+                           GenH5::NodeInfo const& info) -> GenH5::herr_t {
         qDebug() << parent.path() + "/" + info.path;
         return 0;
     }, GenH5::FindRecursive);

--- a/tests/unittests/h5/test_h5_location.cpp
+++ b/tests/unittests/h5/test_h5_location.cpp
@@ -79,7 +79,7 @@ TEST_F(TestH5Location, linkPath)
 
 TEST_F(TestH5Location, fileRefCount)
 {
-    hid_t id = 0;
+    GenH5::hid_t id = 0;
 
     {
         GenH5::Group _root;


### PR DESCRIPTION
## Summary

  Fixes #145.

  HDF5 1.14 changed the underlying types of `hsize_t` and `hssize_t`, causing conflicts with GenH5’s global typedefs.

  ## Changes

  - Move `hsize_t`, `hssize_t`, `hid_t`, and `herr_t` into the `GenH5` namespace without renaming or changing their underlying types.
  - Add private converters between `GenH5::Dimensions` and HDF5-native dimension arrays. (only if conversion is needed)
  - Use HDF5-native `::hsize_t` for iteration indices passed by pointer.
  - Update internal return-type qualification and affected unit tests.

  No HDF5 headers are exposed through public GenH5 headers.

  ## Compatibility

  The underlying GenH5 types remain unchanged, preserving the existing ABI.

  Client code explicitly using the former global typedefs must qualify them, for example:

  ```cpp
  GenH5::hsize_t
  GenH5::hid_t
   ```

  ## Testing

  - Built successfully with HDF5 1.14.6 and Qt 6.
  - All 186 unit tests pass with HDF5 1.14.6.
  - Built successfully with HDF5 1.12.1 and Qt 5.
  - Verified both GenH5/HDF5 header include orders compile.

## Summary by Sourcery

Adapt GenH5’s HDF5 type handling to be namespace-qualified and compatible with HDF5 1.14 typedef changes.

Bug Fixes:
- Resolve type conflicts with HDF5 1.14 by moving hsize_t, hssize_t, hid_t, and herr_t into the GenH5 namespace and qualifying their usage.

Enhancements:
- Introduce internal converters between GenH5::Dimensions and native HDF5 dimension arrays to isolate HDF5 type differences.
- Update APIs, hooks, and containers to use GenH5-qualified typedefs while using native ::hsize_t where required by HDF5 iteration functions.

Tests:
- Adjust HDF5-related unit tests to use GenH5-qualified typedefs and validate the updated type handling.

## Summary by Sourcery

Adapt GenH5’s type system and internal HDF5 interactions to be namespace-qualified and compatible with HDF5 1.14’s typedef changes while preserving ABI.

Bug Fixes:
- Resolve HDF5 1.14 typedef conflicts by moving GenH5-specific hsize_t, hssize_t, hid_t, and herr_t into the GenH5 namespace and updating usages.

Enhancements:
- Introduce internal compatibility helpers to convert between GenH5::Dimensions and native HDF5 dimension arrays where needed.
- Qualify internal APIs, hooks, and containers with GenH5 typedefs while using native ::hsize_t for HDF5 iteration indices.
- Adjust dataspace, datatype, dataset, property list, group, node, file, and attribute handling to use the new type strategy consistently.

Documentation:
- Document the namespace move of HDF5-related typedefs and its impact on client code in the changelog.

Tests:
- Update HDF5-related unit tests to use GenH5-qualified typedefs and validate the new dimension and hook handling, including additional layout checks for tuple utilities.